### PR TITLE
Only add 'X-Requested-With' when request body is supplied

### DIFF
--- a/src/plugins/fn.ajax/fn.ajax.js
+++ b/src/plugins/fn.ajax/fn.ajax.js
@@ -5,12 +5,15 @@ function ajax (action, opt, done, before) {
 
   // A bunch of options and defaults
   opt = opt || {};
+  var bodyProvided = !!opt.body;
   opt.body = opt.body || {};
   opt.method = (opt.method || 'GET').toUpperCase();
   opt.headers = opt.headers || {};
 
   // Tell the back-end it's an AJAX request
-  opt.headers['X-Requested-With'] = opt.headers['X-Requested-With'] || 'XMLHttpRequest';
+  if (bodyProvided) {
+    opt.headers['X-Requested-With'] = opt.headers['X-Requested-With'] || 'XMLHttpRequest';
+  }
 
   if (typeof window.FormData === 'undefined' || !(opt.body instanceof window.FormData)) {
     opt.headers['Content-Type'] = opt.headers['Content-Type'] || 'application/x-www-form-urlencoded';


### PR DESCRIPTION
A minimal change to fix #112, mimicking the identical logic in [nanoajax](https://github.com/yanatan16/nanoajax/blob/master/index.js#L74). It may be even better to add an option to not add it automatically (see [discussion at nanoajax](https://github.com/yanatan16/nanoajax/issues/21#issuecomment-300729955)).