### PR TITLE
Added .css() method

### DIFF
--- a/umbrella.js
+++ b/umbrella.js
@@ -656,6 +656,17 @@ u.prototype.size = function () {
 };
 
 
+// Implementation of .css() method
+u.prototype.css = function (property, value) {
+	if(value == undefined){
+		return window.getComputedStyle(this.first())[property];
+	}
+	this.each(function (el) {
+		el.style[property] = value;
+	})
+	return this;
+}
+
 // [INTERNAL USE ONLY]
 
 // Force it to be an array AND also it clones them


### PR DESCRIPTION
A .css() method to get or set css properties of or to element(s). While getting a value, just pass the property name. It will return the computed style for the given property for the first matched element. When setting a property, give it a property and a value argument. It will set them for all the matched elements.