### PR TITLE
Update docs for wrap plugin

### DIFF
--- a/src/plugins/wrap/readme.md
+++ b/src/plugins/wrap/readme.md
@@ -25,7 +25,7 @@ Wrap an element in an html element:
 
 Original element:
 ```html
-<button class="example">Link1</button>
+<span class="example">Link1</span>
 ```
 
 ```js
@@ -35,7 +35,7 @@ u(".example").wrap('<a class="wrapper">');
 Result:
 ```html
 <a class="wrapper">
-  <button class="example">Link1</button>
+  <span class="example">Link1</span>
 </a>
 ```
 
@@ -48,16 +48,16 @@ u(".example").wrap('<a>').attr({class: "wrapper", href: "http://google.com"});
 Result:
 ```html
 <a href="http://google.com" class="wrapper">
-  <button class="example">Link1</button>
+  <span class="example">Link1</span>
 </a>
 ```
 
 Wrap several elements in an html element
 
 ```html
-<button class="example">Link1</button>
-<button class="example">Link2</button>
-<button class="example">Link3</button>
+<span class="example">Link1</span>
+<span class="example">Link2</span>
+<span class="example">Link3</span>
 
 ```
 
@@ -68,20 +68,20 @@ u(".example").wrap('<a>').attr({class: "wrapper", href: "http://google.com"});
 Result:
 ```html
 <a href="http://google.com" class="wrapper">
-  <button class="example">Link1</button>
+  <span class="example">Link1</span>
 </a>
 <a href="http://google.com" class="wrapper">
-  <button class="example">Link2</button>
+  <span class="example">Link2</span>
 </a>
 <a href="http://google.com" class="wrapper">
-  <button class="example">Link3</button>
+  <span class="example">Link3</span>
 </a>
 ```
 
 Nested selector arguments:
 
 ```html
-<button class="example">Link1</button>
+<span class="example">Link1</span>
 ```
 
 ```js
@@ -94,7 +94,7 @@ Result:
 	<div class="b1">
 		<div class="c1">
 			<a href="http://google.com" class="wrapper">
-			  <button class="example">Link1</button>
+			  <span class="example">Link1</span>
 			</a>
 		</div>
 	</div>
@@ -104,7 +104,7 @@ Result:
 Nested selector arguments with multiple child nodes:
 
 ```html
-<button class="example">Link1</button>
+<span class="example">Link1</span>
 ```
 
 ```js
@@ -117,7 +117,7 @@ Result:
 	<div class="b1">
 		<div class="c1">
 			<a href="http://google.com" class="wrapper">
-			  <button class="example">Link1</button>
+			  <span class="example">Link1</span>
 			</a>
 		</div>
 	</div>


### PR DESCRIPTION
Hi @franciscop, really nice library! Just had a quick update for the documentation to make the `wrap` examples accessible, see notes below. I didn't run any of the build steps to generate a new version, I figured you'd be the one to do that if/when you merge and make a new release, but if you'd like I can do that as well. Thank you. 

Previously this documentation section included examples which wrap a
`button` element inside an `a` element. This is not permitted in the
[HTML spec](https://w3c.github.io/html-reference/button.button.html#button.button-constraints),
as interactive elements cannot be children of other interactive
elements.

This was also an inaccessible example, seeing as typical keyboard and
screenreader focus for buttons and links will be either inconsistent or
broken depending on the browser

Went through and updated the examples to change the `button` to a
`span`, which is proper accessible HTML 👍