### PR TITLE
Distribute TypeScript definitions

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,7 +30,8 @@
     "src",
     "polyfill.js",
     "umbrella.js",
-    "umbrella.esm.js"
+    "umbrella.esm.js",
+    "umbrella.d.ts"
   ],
   "devDependencies": {
     "grunt": "^1.0.3",


### PR DESCRIPTION
Hello,
I noticed there exists TypeScript definition for Umbrella JS, but the file is not included in release distribution.

Without the file is Umbrella JS unusable from TypeScript.